### PR TITLE
Fix 'path template' text to match fact that '/' is not allowed at beginning.

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -87,7 +87,7 @@ export class YouTubeTemplatePluginSettingsTab extends PluginSettingTab {
     new Setting(containerEl)
       .setName('Path template')
       .setDesc(
-        "Choose the path where you want to save the notes. You can use all keywords that are available in the template (like {{title}}, {{channelName}} etc) and make something like '/YouTube/{{channelName}}/{{title}}.md'.",
+        "Choose the path where you want to save the notes. You can use all keywords that are available in the template (like {{title}}, {{channelName}} etc) and make something like 'YouTube/{{channelName}}/{{title}}.md'.",
       )
       .addText((text) =>
         text.setValue(this.plugin.settings.pathTemplate).onChange(async (value) => {


### PR DESCRIPTION
![Screenshot 2024-05-06 145723](https://github.com/sundevista/youtube-template/assets/83998/5402074f-656c-4b0a-b2e1-1a4aa5ede607)
