### PR TITLE
Obey relative path when downloading thumbnail.

### DIFF
--- a/src/apis/youtube.ts
+++ b/src/apis/youtube.ts
@@ -1,5 +1,5 @@
 import { App, TFolder, requestUrl } from 'obsidian';
-import { filterStringData, getAttachmentFolder, parseChapters, parseISODuration, parseVideoId } from 'src/utils/parser';
+import { filterStringData, parseChapters, parseISODuration, parseVideoId } from 'src/utils/parser';
 import { YouTubeTemplatePluginSettings } from '../settings';
 import { VideoData } from '../types/video-data';
 import { ChannelListResponse, Thumbnail, VideoListResponse } from '../types/youtube-response';

--- a/src/utils/parser.ts
+++ b/src/utils/parser.ts
@@ -57,21 +57,3 @@ export function filterFilename(text: string): string {
 export function filterStringData(text: string): string {
   return text.replace(/"(.*?)"/g, '«$1»').replace(/["]/g, '');
 }
-
-export function getAttachmentFolder(app: App): string {
-  const attachentPath = app.vault.getConfig('attachmentFolderPath');
-
-  if (attachentPath.startsWith('./')) {
-    if (attachentPath.length === 2) return '/';
-
-    const activeFile = app.workspace.getActiveFile();
-    if (!activeFile) throw new Error("No active file. Can't parse the path for the attachment folder.");
-
-    let parentFolder = activeFile?.parent?.path;
-    if (parentFolder?.startsWith('/')) parentFolder = parentFolder.substring(1);
-
-    return parentFolder + attachentPath.substring(2);
-  }
-
-  return attachentPath;
-}


### PR DESCRIPTION
I was noticing that even though my config is set to "same folder as current file" for attachments, the thumbnail images would be downloaded to the root (`/`) of my vault. And I imagine that this is partly because the "current file" (which I think should be the new file this plugin is about to create) does not exist yet. However, even after it has been created, the relative path was not being obeyed by this plugin's `getAttachmentPath` method.

This reworks the thumbnail download timing so that it will wait until it knows the video title & that the folder exists for the video before it downloads & writes the thumbnail to that folder. This means it can also use the video title for the thumbnail filename, rather than a timestamp integer.