### PR TITLE
Added new template variable {{noteCreatedDateTime}}

### DIFF
--- a/src/apis/youtube.ts
+++ b/src/apis/youtube.ts
@@ -51,6 +51,7 @@ export async function getVideoData(videoUrl: string, settings: YouTubeTemplatePl
       description: '',
       //@ts-ignore
       noteCreated: moment().format('YYYY-MM-DD'),
+      noteCreatedDateTime: moment().format('YYYY-MM-DD HH:mm'),
       youtubeUrl: videoUrl,
     };
   } catch (error) {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -143,7 +143,7 @@ export class YouTubeTemplatePluginSettingsTab extends PluginSettingTab {
         'Make the template that will be used to create the note. You can use the following variables: {{title}}, ' +
           '{{channelName}}, {{subscribers}}, {{length}}, {{publishDate}}, {{thumbnail}} (to download thumbnail, ' +
           'file name will be returned), {{thumbnailUrl}} {{chapters}}, {{hashtags}}, ' +
-          '{{description}}, {{noteCreated}}, {{youtubeUrl}}.',
+          '{{description}}, {{noteCreated}}, {{noteCreatedDateTime}}, {{youtubeUrl}}.',
       )
       .addTextArea((text) =>
         text.setValue(this.plugin.settings.template).onChange(async (value) => {
@@ -169,7 +169,7 @@ export class YouTubeTemplatePluginSettingsTab extends PluginSettingTab {
         'File with template that will be used to create the note. You can use the following You can use the following variables: {{title}}, ' +
           '{{channelName}}, {{subscribers}}, {{length}}, {{publishDate}}, {{thumbnail}} (to download thumbnail, ' +
           'file name will be returned), {{thumbnailUrl}} {{chapters}}, {{hashtags}}, ' +
-          '{{description}}, {{noteCreated}}, {{youtubeUrl}}.',
+          '{{description}}, {{noteCreated}}, {{noteCreatedDateTime}}, {{youtubeUrl}}.',
       )
       .addText((text) =>
         text.setValue(this.plugin.settings.templateFile).onChange(async (value) => {

--- a/src/types/video-data.ts
+++ b/src/types/video-data.ts
@@ -11,5 +11,6 @@ export interface VideoData {
   thumbnailUrl: string;
   description: string;
   noteCreated: string;
+  noteCreatedDateTime: string;
   youtubeUrl: string;
 }

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -25,6 +25,7 @@ hashtags: \n{{hashtags}}
 thumbnail: "![[{{thumbnail}}]]"
 description: "{{description}}"
 note_created: "{{noteCreated}}"
+note_modifiend: "{{noteCreatedDateTime}}"
 youtube_url: "{{youtubeUrl}}"
 template-type: "YouTube"
 template-version: "1.0"


### PR DESCRIPTION
Hi!
I miss the option to paste note created date with date and time. I've simply added another variable for that, but in future it probably better to give users option to configure format.